### PR TITLE
[27기 홍유진] Product Component Connection Sync

### DIFF
--- a/public/data/product_data.json
+++ b/public/data/product_data.json
@@ -10,11 +10,11 @@
       "korean_name": "당근케이크",
       "order_quantity": 10,
       "price": "7000.00",
-      "thumbnail_image_url": "/images/choco.jpg",
+      "thumbnail_image_url": "/images/oReo.jpg",
       "vegan_or_not": true,
       "review_num": 30,
       "like_num": 20,
-      "description": "#당충전"
+      "description": "#생일축하해"
     },
     {
       "category": {
@@ -30,7 +30,7 @@
       "vegan_or_not": false,
       "review_num": 40,
       "like_num": 10,
-      "description": "#당충전"
+      "description": "#1시간순삭"
     },
     {
       "category": {
@@ -42,11 +42,11 @@
       "korean_name": "치즈케이크",
       "order_quantity": 150,
       "price": "7000.00",
-      "thumbnail_image_url": "/images/choco.jpg",
+      "thumbnail_image_url": "/images/blueBerry.jpg",
       "vegan_or_not": true,
       "review_num": 35,
       "like_num": 22,
-      "description": "#당충전"
+      "description": "#친구와함께"
     },
     {
       "category": {
@@ -58,11 +58,11 @@
       "korean_name": "에그타르트",
       "order_quantity": 20,
       "price": "5000.00",
-      "thumbnail_image_url": "/images/choco.jpg",
+      "thumbnail_image_url": "/images/x-Mas.jpg",
       "vegan_or_not": false,
       "review_num": 10,
       "like_num": 10,
-      "description": "#당충전"
+      "description": "#아아를부르는맛"
     },
     {
       "category": {
@@ -74,7 +74,7 @@
       "korean_name": "딸기타르트",
       "order_quantity": 25,
       "price": "5500.00",
-      "thumbnail_image_url": "/images/choco.jpg",
+      "thumbnail_image_url": "/images/basic.jpg",
       "vegan_or_not": true,
       "review_num": 60,
       "like_num": 70,

--- a/src/components/ProductInfoBox/ProductInfoBox.js
+++ b/src/components/ProductInfoBox/ProductInfoBox.js
@@ -30,7 +30,7 @@ const ProductInfoBox = ({ koreanName, infoTag, price }) => {
       <h3 className="productName">{koreanName}</h3>
       <p className="infoTag">{infoTag}</p>
       <div className="price">
-        <p className="originPrice">{price.toLocaleString()}</p>
+        <p className="originPrice">{Math.round(price)}</p>
       </div>
       <ul className="tabBar">
         <li className="infoToBuy">구매정보</li>

--- a/src/pages/ProductList/ModalBuyNow/ModalBuyNow.js
+++ b/src/pages/ProductList/ModalBuyNow/ModalBuyNow.js
@@ -1,21 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import '../ModalBuyNow/ModalBuyNow.scss';
 import ProductInfoBox from '../../../components/ProductInfoBox/ProductInfoBox';
 
-const ModalBuyNow = ({ setIsPopModal, infoTag }) => {
-  const [dataOfBuyNow, setDataOfBuyNow] = useState([]);
-
+const ModalBuyNow = ({ setIsPopModal, infoTag, product }) => {
   const clickRemoveModal = () => {
     setIsPopModal(prev => !prev);
   };
-
-  useEffect(() => {
-    fetch('/data/productData.json')
-      .then(response => response.json())
-      .then(data => {
-        setDataOfBuyNow(data);
-      });
-  }, []);
 
   return (
     <div className="popUp">
@@ -24,28 +14,27 @@ const ModalBuyNow = ({ setIsPopModal, infoTag }) => {
       </button>
       <div className="inner">
         <div className="imageBox">
-          <img className="imageMain" src="images/x-Mas.jpg" alt="product" />
+          <img
+            className="imageMain"
+            src={product.thumbnail_image_url}
+            alt="product"
+          />
           <div className="smallImagesLine">
             <div className="smallImageBox">
               <img
                 className="smallImage"
-                src="images/x-Mas.jpg"
+                src={product.thumbnail_image_url}
                 alt="product to small"
               />
             </div>
           </div>
         </div>
-
-        {dataOfBuyNow
-          .filter(e => e.id === 0)
-          .map(product => (
-            <ProductInfoBox
-              koreanName={product.korean_name}
-              infoTag={infoTag}
-              price={product.price}
-              key={product.id}
-            />
-          ))}
+        <ProductInfoBox
+          koreanName={product.korean_name}
+          infoTag={infoTag}
+          price={product.price}
+          key={product.id}
+        />
       </div>
     </div>
   );

--- a/src/pages/ProductList/Product/Product.js
+++ b/src/pages/ProductList/Product/Product.js
@@ -1,34 +1,34 @@
 import React from 'react';
 import './Product.scss';
 import Button from '../../../components/Button/Button';
+import { Link } from 'react-router-dom';
 
-const Product = ({
-  vegan_or_not,
-  infoTag,
-  productName,
-  productImg,
-  productPrice,
-  btnOnClick,
-}) => {
+const Product = ({ el, id, btnOnClick }) => {
   return (
     <div className="product">
       <div className="stickerWrap">
         <div className="stickerBest">BEST</div>
-        {vegan_or_not && <div className="stickerVegan">VEGAN</div>}
+        {el.vegan_or_not && <div className="stickerVegan">VEGAN</div>}
       </div>
       <div className="productContainer">
-        <div className="productImageWrapper">
-          <img className="productImage" alt="example" src={productImg} />
-        </div>
-        <div className="pdtInfo">
-          <p className="infoTag">{infoTag}</p>
-          <h3 className="productName">{productName}</h3>
-          <div className="price">
-            <p className="productPrice">{Math.round(productPrice)}</p>
+        <Link to={`/product/${id}`} className="goToProductDetail">
+          <div className="productImageWrapper">
+            <img
+              className="productImage"
+              alt="example"
+              src={el.thumbnail_image_url}
+            />
           </div>
-        </div>
+          <div className="pdtInfo">
+            <p className="infoTag">{el.description}</p>
+            <h3 className="productName">{el.korean_name}</h3>
+            <div className="price">
+              <p className="productPrice">{Math.round(el.price)}</p>
+            </div>
+          </div>
+        </Link>
         <div className="productButtonContainer">
-          <Button btnOnClick={btnOnClick} point={true}>
+          <Button btnOnClick={event => btnOnClick(el)} point={true}>
             바로구매
           </Button>
           <div className="smallBtn">

--- a/src/pages/ProductList/Product/Product.scss
+++ b/src/pages/ProductList/Product/Product.scss
@@ -15,6 +15,7 @@
 .product {
   overflow: hidden;
   position: relative;
+  min-width: 280px;
   margin: 10px 10px 0 10px;
   padding: 20px 20px 30px 20px;
 
@@ -46,41 +47,42 @@
   .productContainer {
     @include flexCenter(column, space-between);
 
-    .productImageWrapper {
-      @include flexCenter(column, center);
-      width: 260px;
-      height: 260px;
+    .goToProductDetail {
+      .productImageWrapper {
+        @include flexCenter(column, center);
+        width: 260px;
+        height: 260px;
 
-      .productImage {
-        width: 90%;
+        .productImage {
+          width: 90%;
+        }
       }
-    }
-    .pdtInfo {
-      @include flexCenter(column, center);
-      width: 240px;
-      height: 130px;
-      .infoTag {
-        font-size: 14px;
-        color: $darkGrey;
-      }
-      .productName {
-        padding: 0 10px;
-        margin: 20px 0 10px 0;
-        font-size: 18px;
-        font-weight: bold;
-        color: $black;
-      }
-      .price {
-        padding: 0 30px;
-        margin: 5px 0 20px;
-        font-size: 15px;
-        font-weight: bold;
-        color: $black;
+      .pdtInfo {
+        @include flexCenter(column, center);
+        width: 240px;
+        height: 130px;
+        .infoTag {
+          font-size: 14px;
+          color: $darkGrey;
+        }
+        .productName {
+          padding: 0 10px;
+          margin: 20px 0 10px 0;
+          font-size: 18px;
+          font-weight: bold;
+          color: $black;
+        }
+        .price {
+          padding: 0 30px;
+          margin: 5px 0 20px;
+          font-size: 15px;
+          font-weight: bold;
+          color: $black;
+        }
       }
     }
     .productButtonContainer {
       @include flexCenter(row, space-between);
-      // width: 260px;
       opacity: 0;
       transition: all 1s ease-in-out;
 

--- a/src/pages/ProductList/ProductsMain/ProductsMain.js
+++ b/src/pages/ProductList/ProductsMain/ProductsMain.js
@@ -9,9 +9,11 @@ function ProductsMain() {
   const [isProductMainLoading, setIsProductMainLoading] = useState(false);
   const [productsList, setProductsList] = useState([]);
   const [isPopModal, setIsPopModal] = useState(false);
+  const [selectedProduct, setSelectedProduct] = useState({});
 
-  const PopUpModalBuyNow = () => {
+  const PopUpModalBuyNow = product => {
     setIsPopModal(true);
+    setSelectedProduct(product);
   };
 
   const fetchData = async () => {
@@ -36,32 +38,21 @@ function ProductsMain() {
           <ModalBuyNow
             setIsPopModal={setIsPopModal}
             infoTag={productsList.description}
+            product={selectedProduct}
           />
         )}
         <div className={isPopModal ? 'mask' : 'maskOff'} />
         <ImageSlide />
-        <div className="productListHead">현재 판매하는 제품</div>
+        <div className="productListHead">베스트셀러 TOP 5</div>
         <div className="productListContainer">
-          {productsList.map(
-            ({
-              id,
-              vegan_or_not,
-              description,
-              korean_name,
-              thumbnail_image_url,
-              price,
-            }) => (
-              <Product
-                key={id}
-                vegan_or_not={vegan_or_not}
-                infoTag={description}
-                productName={korean_name}
-                productImg={thumbnail_image_url}
-                productPrice={price}
-                btnOnClick={PopUpModalBuyNow}
-              />
-            )
-          )}
+          {productsList.map(el => (
+            <Product
+              el={el}
+              key={el.id}
+              id={el.id}
+              btnOnClick={PopUpModalBuyNow}
+            />
+          ))}
         </div>
       </div>
     )

--- a/src/pages/ProductList/SortedProducts/SortedProducts.js
+++ b/src/pages/ProductList/SortedProducts/SortedProducts.js
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import SortSelectArea from '../../../components/SortSelectArea/SortSelectArea';
 import Product from '../Product/Product';
+import ModalBuyNow from '../ModalBuyNow/ModalBuyNow';
 import { TRANSELATE } from '../Transelate';
 // import { API_ADDRESS } from '../apiConfig';
 import './SortedProducts.scss';
@@ -10,6 +11,13 @@ const SortedProducts = () => {
   const [isProductLoading, setIsProductLoading] = useState(false);
   const [productsList, setProductsList] = useState([]);
   const { mainCategory, subCategory } = useParams();
+  const [isPopModal, setIsPopModal] = useState(false);
+  const [selectedProduct, setSelectedProduct] = useState({});
+
+  const PopUpModalBuyNow = product => {
+    setIsPopModal(true);
+    setSelectedProduct(product);
+  };
 
   const fetchData = useCallback(async () => {
     // let address;
@@ -23,7 +31,6 @@ const SortedProducts = () => {
 
     // const data = await fetch(address);
     const data = await fetch('/data/product_data.json');
-
     const res = await data.json();
     setProductsList(
       res.product_list.sort(
@@ -47,6 +54,14 @@ const SortedProducts = () => {
   return (
     !isProductLoading && (
       <div className="sortedProducts">
+        {isPopModal && (
+          <ModalBuyNow
+            setIsPopModal={setIsPopModal}
+            infoTag={adjustList.description}
+            product={selectedProduct}
+          />
+        )}
+        <div className={isPopModal ? 'mask' : 'maskOff'} />
         <div className="sortedProductsHead">
           <div className="sortedProductsTitle">
             {`${TRANSELATE[mainCategory]}`}
@@ -63,12 +78,12 @@ const SortedProducts = () => {
                   : product.category.name === mainCategory
               )
             : productsList
-          ).map(({ id, description, korean_name, price }) => (
+          ).map(el => (
             <Product
-              key={id}
-              description={description}
-              productName={korean_name}
-              productPrice={price}
+              el={el}
+              key={el.id}
+              id={el.id}
+              btnOnClick={PopUpModalBuyNow}
             />
           ))}
         </div>

--- a/src/pages/ProductList/SortedProducts/SortedProducts.scss
+++ b/src/pages/ProductList/SortedProducts/SortedProducts.scss
@@ -4,6 +4,21 @@
   @include flexCenter(column, center);
   padding: 0 60px;
 
+  .maskOff {
+    display: none;
+  }
+
+  .mask {
+    width: 110%;
+    height: 100%;
+    background-color: rgba(34, 34, 34, 0.7);
+    z-index: 1000;
+    position: fixed;
+    top: 0;
+    left: 0;
+    left: -90px;
+  }
+
   .sortedProductsHead {
     @include flexCenter(row, space-between);
     width: 100%;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 제품 컴포넌트의 버튼을 클릭했을 때, 해당 제품의 data를 가진 모달창이 뜰 수 있게 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 제품 컴포넌트 레이아웃 및 네스팅
- 제품 컴포넌트에서 필요한 data들을 바탕으로 다시 스타일을 적요함. 
- 스타일을 적용하고, 이동이 필요한 버튼에 Link 태그를 적용하여 이동시킴.

2. 버튼 컴포넌트를 제품 컴포넌트에 적용
- 제품컴포넌트에 버튼을 적용시키면서 생기는 싱크들을 맞춤.
- 애니메이션 효과로 인해 발생한 버벅거림을 스무스하게 수정함.

3. 버튼 클릭시, 해당 제품의 data를 가진 모달창이 뜰 수 있게 구현
- map으로 뿌려진 제품컴포넌트 하나의 값을 modal 창에 띄워주기 위해 lifting state를 적용함.
- 단방향 데이터 흐름을 가진 리액트의 구조에 따라 부모 요소에서 데이터를 관리하게 해주기 위해 제품 컴포넌트의 props에 버튼 클릭시, `{event => btnOnClick(el)}` 인자를 넣어서 부모에게 props로 받았던 값을 올려줌.
- 부모에서 새로운 객체 state를 만들고, 그 state의 변화된 값, 즉 setState를 바꿔주는 함수를 만들어 인자값을 받을 수 있게 함.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 애니메이션 마지막 상태유지 : animation: fadeIn 1.5s forwards 를 넣어준다.

- 모달창 컴포넌트의 위치 :  팀 프로젝트에서 컴포넌트화 개발을 진행하고 연결해보면서 싱크가 안맞는 부분이 생기기 시작했다. 단일 제품 컴포넌트를 map으로 뿌려준 부모 컴포넌트 (= productMain.js)에서 모달창 컴포넌트를 띄워줄지, 단일제품컴포넌트에서 모달창을 띄워줘야할지 상당히 팀원들과 고민한 결과, 부모 컴포넌트 (= productMain.js)에 넣어주기로 결정했다. 그 이유는 최상단에서 state를 관리하는 것이 좋겠다고 생각했고 모달창이 뜨면서 mask를 밑부분에 씌워줘야했기 때문에 그 방안이 적합하다고 생각했다. 

- lifting state up : 모달창 컴포넌트를 부모 컴포넌트 (= productMain.js)에 넣으면서 product의 데이터를 어떻게 모달창에 받아서 띄워줄지 하루종일 고민하였다. 우선 product는 부모컴포넌트에서 모든 데이터를 받아 map으로 뿌려지고 있었고 해당 컴포넌트의 값만 가져와서 모달창에 뿌려주는 것은 리액트의 "단방향 데이터 흐름"을 거스르는 일이었다. 그래서 진짜 거슬러 버렸다. 공식문서와 강의들을 봐도 이해가 가지 않아서 고민을 많이 했는데 동기들과 얘기를 해보고 + console.log를 계속 찍어보면서 점진적 개발을 진행하였다. 시간이 조금 걸렸지만 결국 성공하였다. 제품컴포넌트에서 받은 props를 모두 내려받고, 그 props들을 이벤트(버튼클릭)가 발생할 때 부모에게 해당 데이터를 전달하려면, 이벤트(버튼클릭)에 콜백함수를 실어 인자로 이벤트를 넣어주고, 버튼클릭함수의 인자로는 props를 넣어줘서 부모로 올렸다. 그리고 부모 컴포넌트 (= productMain.js)에서는 (올려받은) 해당데이터를 담을 새로운 객체 state를 만들고 state를 바꿔줄 함수를 선언한다. 그 함수를 이제 모달의 props로 넣어주면서 해결되었다. 힘든 여정이었지만 이 경험을 통해 리액트의 성격을 한번 더 공부할 수 있게 되었다. 그치만 얼른 리덕스 써보고 싶다. 

<br />

## :: 기타 질문 및 특이 사항
- 27기 동기여러분과 멘토님들께 감사합니다 !!
